### PR TITLE
Add FastAPI backend and TypeScript frontend for file-based sentiment analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ sudo apt install -y python3 python3-venv python3-pip nodejs npm nginx
 ### Step B — Copy project to server
 
 ```bash
-git clone <your-repo-url> sentiment-app
+git clone https://github.com/omosaiye/sentimentAnn.git sentiment-app
 cd sentiment-app
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,193 @@
-# solaidigital
-Solai digital assets
+# Sentiment Analysis Web App (FastAPI + TypeScript)
+
+A simple one-page web app that lets you upload multiple files and get sentiment predictions for each file.
+
+- **Backend:** FastAPI + Hugging Face Transformers
+- **Model:** `cardiffnlp/twitter-roberta-base-sentiment-latest` (widely used open-source sentiment model)
+- **Frontend:** One-page TypeScript UI (bundled with esbuild)
+
+---
+
+## 1) Project structure
+
+```text
+backend/
+  main.py
+  requirements.txt
+frontend/
+  package.json
+  src/app.ts
+  public/
+    index.html
+    styles.css
+    app.js (generated)
+```
+
+---
+
+## 2) Local run (quick test)
+
+### Backend
+
+```bash
+cd backend
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+uvicorn main:app --host 0.0.0.0 --port 8000
+```
+
+### Frontend build + serve
+
+Open a second terminal:
+
+```bash
+cd frontend
+npm install
+npm run build
+python3 -m http.server 8080 --directory public
+```
+
+Now open: `http://localhost:8080`
+
+Set **Backend API URL** to: `http://localhost:8000`
+
+---
+
+## 3) Deploy on Ubuntu cloud server (production-ish setup)
+
+### Step A — Install system dependencies
+
+```bash
+sudo apt update
+sudo apt install -y python3 python3-venv python3-pip nodejs npm nginx
+```
+
+### Step B — Copy project to server
+
+```bash
+git clone <your-repo-url> sentiment-app
+cd sentiment-app
+```
+
+### Step C — Build backend environment
+
+```bash
+cd backend
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+### Step D — Build frontend
+
+```bash
+cd ../frontend
+npm install
+npm run build
+```
+
+### Step E — Create a systemd service for FastAPI
+
+Create `/etc/systemd/system/sentiment-api.service`:
+
+```ini
+[Unit]
+Description=Sentiment FastAPI Service
+After=network.target
+
+[Service]
+User=ubuntu
+WorkingDirectory=/home/ubuntu/sentiment-app/backend
+Environment="PATH=/home/ubuntu/sentiment-app/backend/.venv/bin"
+ExecStart=/home/ubuntu/sentiment-app/backend/.venv/bin/uvicorn main:app --host 127.0.0.1 --port 8000
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable sentiment-api
+sudo systemctl start sentiment-api
+sudo systemctl status sentiment-api
+```
+
+### Step F — Configure Nginx for frontend + API proxy
+
+Create `/etc/nginx/sites-available/sentiment-app`:
+
+```nginx
+server {
+    listen 80;
+    server_name _;
+
+    root /home/ubuntu/sentiment-app/frontend/public;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /analyze {
+        proxy_pass http://127.0.0.1:8000/analyze;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location /health {
+        proxy_pass http://127.0.0.1:8000/health;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+Enable and reload Nginx:
+
+```bash
+sudo ln -s /etc/nginx/sites-available/sentiment-app /etc/nginx/sites-enabled/sentiment-app
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+Visit your server IP in a browser.
+
+---
+
+## 4) About your Ollama Cloud account
+
+This implementation uses a high-quality open-source Hugging Face sentiment model directly in Python, so **Ollama Cloud is optional**.
+
+If you want, a next step is replacing the classifier with an Ollama-hosted model and calling it from FastAPI. The UI and API contract can stay the same.
+
+---
+
+## 5) API contract
+
+### `POST /analyze`
+
+- **Form field:** `files` (one or many uploads)
+- **Returns:** per-file sentiment label and confidence score
+
+Example response:
+
+```json
+{
+  "model": "cardiffnlp/twitter-roberta-base-sentiment-latest",
+  "total_files": 2,
+  "results": [
+    {
+      "filename": "note1.txt",
+      "label": "positive",
+      "score": 0.9921,
+      "chars_analyzed": 847
+    }
+  ]
+}
+```

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import FastAPI, File, HTTPException, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from transformers import pipeline
+
+MODEL_NAME = "cardiffnlp/twitter-roberta-base-sentiment-latest"
+MAX_CHARS_PER_FILE = 12000
+
+app = FastAPI(title="File Sentiment API", version="1.0.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+classifier = pipeline("sentiment-analysis", model=MODEL_NAME, truncation=True)
+
+
+class FileSentiment(BaseModel):
+    filename: str
+    label: str
+    score: float
+    chars_analyzed: int
+
+
+class SentimentResponse(BaseModel):
+    model: str
+    total_files: int
+    results: List[FileSentiment]
+
+
+@app.get("/health")
+def health() -> dict:
+    return {"status": "ok", "model": MODEL_NAME}
+
+
+@app.post("/analyze", response_model=SentimentResponse)
+async def analyze(files: List[UploadFile] = File(...)) -> SentimentResponse:
+    if not files:
+        raise HTTPException(status_code=400, detail="No files uploaded")
+
+    results: List[FileSentiment] = []
+
+    for uploaded in files:
+        raw = await uploaded.read()
+        if not raw:
+            continue
+
+        try:
+            text = raw.decode("utf-8", errors="ignore").strip()
+        except Exception as exc:  # defensive
+            raise HTTPException(status_code=400, detail=f"Could not read {uploaded.filename}: {exc}")
+
+        if not text:
+            continue
+
+        text = text[:MAX_CHARS_PER_FILE]
+        prediction = classifier(text)[0]
+
+        results.append(
+            FileSentiment(
+                filename=uploaded.filename,
+                label=prediction["label"],
+                score=round(float(prediction["score"]), 4),
+                chars_analyzed=len(text),
+            )
+        )
+
+    if not results:
+        raise HTTPException(status_code=400, detail="No readable text found in uploaded files")
+
+    return SentimentResponse(model=MODEL_NAME, total_files=len(results), results=results)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.115.12
+uvicorn[standard]==0.34.2
+python-multipart==0.0.20
+transformers==4.51.3
+torch==2.7.0

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "sentiment-ui",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "build": "esbuild src/app.ts --bundle --outfile=public/app.js --minify"
+  },
+  "devDependencies": {
+    "esbuild": "^0.25.3"
+  }
+}

--- a/frontend/public/app.js
+++ b/frontend/public/app.js
@@ -1,0 +1,42 @@
+const form = document.querySelector('#upload-form');
+const apiInput = document.querySelector('#api-url');
+const fileInput = document.querySelector('#files');
+const statusEl = document.querySelector('#status');
+const tableBody = document.querySelector('#results tbody');
+
+const setStatus = (message, isError = false) => {
+  statusEl.textContent = message;
+  statusEl.style.color = isError ? '#b91c1c' : '#1f2937';
+};
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  tableBody.innerHTML = '';
+
+  if (!fileInput.files || fileInput.files.length === 0) {
+    setStatus('Please select at least one file.', true);
+    return;
+  }
+
+  const formData = new FormData();
+  Array.from(fileInput.files).forEach((file) => formData.append('files', file));
+
+  const apiBase = apiInput.value.replace(/\/$/, '');
+  setStatus('Analyzing files...');
+
+  try {
+    const response = await fetch(`${apiBase}/analyze`, { method: 'POST', body: formData });
+    if (!response.ok) throw new Error(await response.text());
+
+    const data = await response.json();
+    data.results.forEach((item) => {
+      const row = document.createElement('tr');
+      row.innerHTML = `<td>${item.filename}</td><td>${item.label}</td><td>${item.score.toFixed(4)}</td><td>${item.chars_analyzed}</td>`;
+      tableBody.appendChild(row);
+    });
+
+    setStatus(`Done. Model: ${data.model}. Files analyzed: ${data.total_files}.`);
+  } catch (error) {
+    setStatus(`Error: ${error.message}`, true);
+  }
+});

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sentiment Analyzer</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main>
+      <h1>File Sentiment Analyzer</h1>
+      <p>Upload text-based files and run sentiment analysis.</p>
+
+      <form id="upload-form">
+        <label>
+          Backend API URL
+          <input id="api-url" type="url" value="http://localhost:8000" required />
+        </label>
+
+        <label>
+          Files
+          <input id="files" type="file" multiple required />
+        </label>
+
+        <button type="submit">Analyze</button>
+      </form>
+
+      <p id="status"></p>
+
+      <table id="results">
+        <thead>
+          <tr>
+            <th>Filename</th>
+            <th>Label</th>
+            <th>Confidence</th>
+            <th>Characters Analyzed</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </main>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/frontend/public/styles.css
+++ b/frontend/public/styles.css
@@ -1,0 +1,47 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 2rem;
+  background: #f8fafc;
+  color: #0f172a;
+}
+
+main {
+  max-width: 900px;
+  margin: 0 auto;
+  background: white;
+  padding: 1.5rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+}
+
+form {
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+input,
+button {
+  padding: 0.6rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  border: 1px solid #e2e8f0;
+  padding: 0.6rem;
+  text-align: left;
+}
+
+th {
+  background: #f1f5f9;
+}

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -1,0 +1,67 @@
+type SentimentResult = {
+  filename: string;
+  label: string;
+  score: number;
+  chars_analyzed: number;
+};
+
+type ApiResponse = {
+  model: string;
+  total_files: number;
+  results: SentimentResult[];
+};
+
+const form = document.querySelector<HTMLFormElement>("#upload-form")!;
+const apiInput = document.querySelector<HTMLInputElement>("#api-url")!;
+const fileInput = document.querySelector<HTMLInputElement>("#files")!;
+const statusEl = document.querySelector<HTMLParagraphElement>("#status")!;
+const tableBody = document.querySelector<HTMLTableSectionElement>("#results tbody")!;
+
+const setStatus = (message: string, isError = false) => {
+  statusEl.textContent = message;
+  statusEl.style.color = isError ? "#b91c1c" : "#1f2937";
+};
+
+form.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  tableBody.innerHTML = "";
+
+  if (!fileInput.files || fileInput.files.length === 0) {
+    setStatus("Please select at least one file.", true);
+    return;
+  }
+
+  const formData = new FormData();
+  Array.from(fileInput.files).forEach((file) => formData.append("files", file));
+
+  const apiBase = apiInput.value.replace(/\/$/, "");
+  setStatus("Analyzing files...");
+
+  try {
+    const response = await fetch(`${apiBase}/analyze`, {
+      method: "POST",
+      body: formData,
+    });
+
+    if (!response.ok) {
+      throw new Error(await response.text());
+    }
+
+    const data = (await response.json()) as ApiResponse;
+
+    data.results.forEach((item) => {
+      const row = document.createElement("tr");
+      row.innerHTML = `
+        <td>${item.filename}</td>
+        <td>${item.label}</td>
+        <td>${item.score.toFixed(4)}</td>
+        <td>${item.chars_analyzed}</td>
+      `;
+      tableBody.appendChild(row);
+    });
+
+    setStatus(`Done. Model: ${data.model}. Files analyzed: ${data.total_files}.`);
+  } catch (error) {
+    setStatus(`Error: ${(error as Error).message}`, true);
+  }
+});


### PR DESCRIPTION
### Motivation
- Provide a simple web app that accepts multiple uploaded files and returns per-file sentiment using a high-quality open-source model. 
- Use `FastAPI` for a lightweight backend API and a minimal TypeScript single-page UI so the app is easy to run and deploy on an Ubuntu cloud server. 
- Offer a straightforward deployment guide (systemd + Nginx) and an Ollama-compatible integration note so the implementation can be swapped to a hosted model later. 

### Description
- Added a FastAPI backend at `backend/main.py` exposing `POST /analyze` and `GET /health` and loading the `cardiffnlp/twitter-roberta-base-sentiment-latest` model via Hugging Face `pipeline` with CORS enabled. 
- Added backend dependency list in `backend/requirements.txt` including `fastapi`, `uvicorn`, `transformers`, and `torch`. 
- Added a one-page TypeScript frontend (`frontend/src/app.ts`) plus static assets (`frontend/public/index.html`, `styles.css`) and a prebuilt `frontend/public/app.js` fallback, and a `package.json` with an `esbuild` build script. 
- Added a comprehensive `README.md` with project structure, local run steps, deployment instructions for Ubuntu (systemd + Nginx), and notes about using Ollama Cloud as an optional next step. 

### Testing
- Ran `python3 -m py_compile backend/main.py` which completed successfully. 
- Attempted `cd frontend && npm install && npm run build` which failed in this environment due to npm registry access restrictions (HTTP 403), so a prebuilt `frontend/public/app.js` was included as a fallback and the UI was validated by static inspection. 
- No additional automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f394e1f474832987a5316a7bae0507)